### PR TITLE
fix: add missing coverage script for CI badge generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"check": "bun clean && bun bundle --all --quiet && bun test",
 		"bundle": "bun ./scripts/bundle.mjs",
 		"clean": "bun ./scripts/clean.mjs",
+		"coverage": "bun test --coverage",
 		"format": "biome check --write ./",
 		"changeset": "changeset",
 		"badges": "bun ./scripts/badges.mjs",


### PR DESCRIPTION
The CI workflow was calling 'bun coverage' but no coverage script was defined in package.json, causing the coverage badge to show 'unknown'. This adds the missing script using 'bun test --coverage'.

Fixes #62

Generated with [Claude Code](https://claude.ai/code)