### PR TITLE
Remove router hash support from tests

### DIFF
--- a/tests/router/basic.test.ts
+++ b/tests/router/basic.test.ts
@@ -14,7 +14,6 @@ describe("router", () => {
 
     afterEach(() => {
       document.body.removeChild(appContainer);
-      window.location.hash = "";
     });
 
     test("navigate to the home page", () => {
@@ -184,83 +183,6 @@ describe("router", () => {
     });
   });
 
-  describe("hash", () => {
-    let appContainer: HTMLElement;
-    beforeEach(() => {
-      appContainer = document.createElement("div");
-      document.body.appendChild(appContainer);
-      window.history.replaceState({}, "", "/");
-      window.location.hash = "";
-    });
-    afterEach(() => {
-      document.body.removeChild(appContainer);
-      window.location.hash = "";
-    });
-
-    test("navigate to static routes using hash paths", async () => {
-      router({
-        routes: {
-          "/": () => { appContainer.textContent = "Home"; },
-          "/about": () => { appContainer.textContent = "About"; }
-        },
-        hash: true
-      });
-      navigate("/");
-      await tick();
-      expect(window.location.hash).toBe("#/");
-      expect(appContainer.textContent).toBe("Home");
-      navigate("/about");
-      await tick();
-      expect(window.location.hash).toBe("#/about");
-      expect(appContainer.textContent).toBe("About");
-    });
-
-    test("handle dynamic params in hash routes", async () => {
-      router({
-        routes: {
-          "/users/:id": ({ id }: { id: string }) => { appContainer.textContent = `User ${id}`; }
-        },
-        hash: true
-      });
-      navigate("/users/42");
-      await tick();
-      expect(window.location.hash).toBe("#/users/42");
-      expect(appContainer.textContent).toBe("User 42");
-      expect(route().params.id).toBe("42");
-    });
-
-    test("handle query params in hash routes", async () => {
-      router({
-        routes: {
-          "/search": (query?: { q?: string }) => {
-            appContainer.textContent = `Query: ${query?.q}`;
-          }
-        },
-        hash: true
-      });
-      navigate("/search", {}, { q: "hash-routing" });
-      await tick();
-      expect(window.location.hash).toBe("#/search?q=hash-routing");
-      expect(appContainer.textContent).toBe("Query: hash-routing");
-      expect(route().query.q).toBe("hash-routing");
-    });
-
-    test("shows not found page for unmatched hash routes", async () => {
-      let notFoundTriggered = false;
-      router({
-        routes: {
-          "/": () => { appContainer.textContent = "Home"; }
-        },
-        hash: true,
-        notFound: () => { notFoundTriggered = true; appContainer.textContent = "Not Found"; }
-      });
-      navigate("/non-existent-hash");
-      await tick();
-      expect(window.location.hash).toBe("#/non-existent-hash");
-      expect(notFoundTriggered).toBe(true);
-      expect(appContainer.textContent).toBe("Not Found");
-    });
-  });
 
 
   describe("async", () => {
@@ -274,7 +196,6 @@ describe("router", () => {
 
     afterEach(() => {
       document.body.removeChild(appContainer);
-      window.location.hash = "";
     });
 
     test("handle promise-returning hooks without throwing", async () => {

--- a/tests/router/nested.test.ts
+++ b/tests/router/nested.test.ts
@@ -14,7 +14,6 @@ describe("router", () => {
 
     afterEach(() => {
       document.body.removeChild(appContainer);
-      window.location.hash = "";
     });
 
     test("match nested routes with 2 levels", () => {
@@ -130,7 +129,6 @@ describe("router", () => {
 
     afterEach(() => {
       document.body.removeChild(appContainer);
-      window.location.hash = "";
     });
 
     test("inherit parameters from parent routes", () => {
@@ -229,7 +227,6 @@ describe("router", () => {
 
     afterEach(() => {
       document.body.removeChild(appContainer);
-      window.location.hash = "";
     });
 
     test("execute hooks in correct order: parent before → child before → child handler → child after → parent after", () => {
@@ -372,7 +369,6 @@ describe("router", () => {
 
     afterEach(() => {
       document.body.removeChild(appContainer);
-      window.location.hash = "";
     });
 
     test("prioritize exact nested matches over flat routes", () => {
@@ -462,7 +458,6 @@ describe("router", () => {
 
     afterEach(() => {
       document.body.removeChild(appContainer);
-      window.location.hash = "";
     });
 
     test("continue to support flat route definitions", () => {
@@ -566,7 +561,6 @@ describe("router", () => {
 
     afterEach(() => {
       document.body.removeChild(appContainer);
-      window.location.hash = "";
     });
 
     test("navigate between different nested routes", () => {
@@ -687,7 +681,6 @@ describe("router", () => {
 
     afterEach(() => {
       document.body.removeChild(appContainer);
-      window.location.hash = "";
     });
 
     test("show 404 for unmatched nested routes", () => {
@@ -801,89 +794,6 @@ describe("router", () => {
     });
   });
 
-  describe("hash", () => {
-    let appContainer: HTMLDivElement;
-
-    beforeEach(() => {
-      appContainer = document.createElement("div");
-      document.body.appendChild(appContainer);
-      window.history.replaceState({}, "", "/");
-      window.location.hash = "";
-    });
-
-    afterEach(() => {
-      document.body.removeChild(appContainer);
-      window.location.hash = "";
-    });
-
-    test("handle nested routes in hash mode", async () => {
-      router({
-        routes: {
-          "/admin": {
-            children: {
-              "/users": {
-                children: {
-                  "/:id": ({ id }: { id: string }) => { appContainer.textContent = `User ${id}`; }
-                }
-              }
-            }
-          }
-        },
-        hash: true
-      });
-
-      navigate("/admin/users/123");
-      await tick();
-      expect(window.location.hash).toBe("#/admin/users/123");
-      expect(appContainer.textContent).toBe("User 123");
-      expect(route().params.id).toBe("123");
-    });
-
-    test("navigate between nested routes in hash mode", async () => {
-      router({
-        routes: {
-          "/app": {
-            children: {
-              "/home": () => { appContainer.textContent = "Home"; },
-              "/profile": () => { appContainer.textContent = "Profile"; }
-            }
-          }
-        },
-        hash: true
-      });
-
-      navigate("/app/home");
-      await tick();
-      expect(window.location.hash).toBe("#/app/home");
-      expect(appContainer.textContent).toBe("Home");
-
-      navigate("/app/profile");
-      await tick();
-      expect(window.location.hash).toBe("#/app/profile");
-      expect(appContainer.textContent).toBe("Profile");
-    });
-
-    test("handle query parameters with nested routes in hash mode", async () => {
-      router({
-        routes: {
-          "/search": {
-            children: {
-              "/advanced": (_: any, query: { term: string }) => {
-                appContainer.textContent = `Advanced: ${query?.term || 'none'}`;
-              }
-            }
-          }
-        },
-        hash: true
-      });
-
-      navigate("/search/advanced", {}, { term: "test query" });
-      await tick();
-      expect(window.location.hash).toBe("#/search/advanced?term=test%20query");
-      expect(appContainer.textContent).toBe("Advanced: test query");
-      expect(route().query.term).toBe("test query");
-    });
-  });
 
   describe("performance", () => {
     let appContainer: HTMLDivElement;
@@ -896,7 +806,6 @@ describe("router", () => {
 
     afterEach(() => {
       document.body.removeChild(appContainer);
-      window.location.hash = "";
     });
 
     test("handle deep nesting efficiently", () => {


### PR DESCRIPTION
Closes #99

Removes all hash-related test cases from router tests following the removal of hash support from the main router code.

## Changes
- Removed complete "hash" describe block from basic.test.ts (4 test cases)
- Removed complete "hash" describe block from nested.test.ts (3 test cases)
- Cleaned up window.location.hash cleanup code from afterEach blocks
- Tests now only cover History API routing, consistent with router implementation

🤖 Generated with [Claude Code](https://claude.ai/code)